### PR TITLE
Add boto3 dependency for Object Storage commands

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -83,6 +83,7 @@ parts:
     source: .
     python-packages:
       - linode-cli==$SNAPCRAFT_PROJECT_VERSION
+      - boto3
 
     override-build: |
       craftctl default


### PR DESCRIPTION
Adds `boto3` to the snap's Python package dependencies so `linode-cli obj` commands work inside the confined snap environment.

Tested locally with:

- `linode-cli --version`
- `linode-cli linodes list`
- `linode-cli obj ls`

`linode-cli obj ls` now loads the Object Storage plugin instead of failing with the missing `boto3` error.