### PR TITLE
Update snap base to core26

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -41,7 +41,7 @@ description: |
   ```bash
   linode-cli --help
   ```
-base: core24
+base: core26
 grade: stable
 confinement: strict
 source-code:
@@ -69,6 +69,8 @@ platforms:
 apps:
   linode-cli:
     command: bin/linode-cli
+    environment:
+      PYTHONPATH: $SNAP/lib/python3.14/site-packages
     completer: completions/linode_cli.bash
     aliases:
       - linode
@@ -81,6 +83,9 @@ parts:
   linode-cli:
     plugin: python
     source: .
+    stage-packages:
+      - python3-minimal
+      - python3-venv
     python-packages:
       - linode-cli==$SNAPCRAFT_PROJECT_VERSION
       - boto3


### PR DESCRIPTION
## Summary

Updates the snap base from `core24` to `core26`.

## Changes

- Updated the snap base from `core24` to `core26`
- Added Python runtime packages required for the `core26` base:
  - `python3-minimal`
  - `python3-venv`
- Added a `PYTHONPATH` environment variable so the bundled Python runtime can locate packages installed by the Snapcraft Python plugin
- Retained existing shell completion generation
- Retained Object Storage (`boto3`) support added previously

## Testing

Built and installed the snap locally using:

```bash
snapcraft clean
snapcraft pack
sudo snap install --dangerous ./linode-cli_5.68.0_amd64.snap
```

Verified:

```bash
linode-cli --version
linode-cli linodes list
linode-cli obj ls
linode-cli completion bash
```

The CLI launches successfully on `core26`, API commands function normally, and Object Storage commands continue to work.